### PR TITLE
Respect clock format in the status line (#50)

### DIFF
--- a/nord.tmux
+++ b/nord.tmux
@@ -22,6 +22,7 @@ __cleanup() {
   unset -v NORD_TMUX_STATUS_CONTENT_OPTION NORD_TMUX_NO_PATCHED_FONT_OPTION
   unset -v _current_dir
   unset -f __load __cleanup
+  tmux set-environment -gu NORD_TMUX_STATUS_TIME_FORMAT
 }
 
 __load() {
@@ -29,6 +30,12 @@ __load() {
 
   local status_content=$(tmux show-option -gqv "$NORD_TMUX_STATUS_CONTENT_OPTION")
   local no_patched_font=$(tmux show-option -gqv "$NORD_TMUX_NO_PATCHED_FONT_OPTION")
+
+  if [ "$(tmux show-option -gqv "clock-mode-style")" == '12' ]; then
+    tmux set-environment -g NORD_TMUX_STATUS_TIME_FORMAT "%I:%M %p"
+  else
+    tmux set-environment -g NORD_TMUX_STATUS_TIME_FORMAT "%H:%M"
+  fi
 
   if [ "$status_content" != "0" ]; then
     if [ "$no_patched_font" != "1" ]; then

--- a/src/nord-status-content-no-patched-font.conf
+++ b/src/nord-status-content-no-patched-font.conf
@@ -16,7 +16,7 @@ set -g @prefix_highlight_copy_mode_attr "fg=black,bg=brightcyan"
 #+--------+
 #+--- Bars ---+
 set -g status-left "#[fg=black,bg=blue,bold] #S "
-set -g status-right "#{prefix_highlight}#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]|#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
+set -g status-right "#{prefix_highlight}#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]|#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
 set -g window-status-format " #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack]#W #F"

--- a/src/nord-status-content.conf
+++ b/src/nord-status-content.conf
@@ -19,7 +19,7 @@ set -g @prefix_highlight_copy_mode_attr "fg=brightcyan,bg=black,bold"
 #+--- Bars ---+
 #set -g status-left "#[fg=black,bg=blue,bold] #S#[fg=blue,bg=black,nobold,noitalics,nounderscore]"
 set -g status-left "#[fg=black,bg=blue,bold] #S #[fg=blue,bg=black,nobold,noitalics,nounderscore]"
-set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H "
+set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
 set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"


### PR DESCRIPTION
Added the new `NORD_TMUX_STATUS_TIME_FORMAT` environment variable that
stores the time format for the status bar element based on the value of
the `clock-mode-style` configuration. This can be either `12` or `24`
and the display format will be changed based on this to ensure the clock
element in the default status bar content matches the preferred style of
the user.

Resolves GH-24